### PR TITLE
Voter basic validations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,11 @@ capybara-*.html
 **.orig
 rerun.txt
 pickle-email-*.html
+.ruby-version
+.ruby-gemset
 
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
+config/database.yml
 config/initializers/secret_token.rb
 config/secrets.yml
 

--- a/app/models/voter.rb
+++ b/app/models/voter.rb
@@ -1,4 +1,10 @@
 class Voter < ActiveRecord::Base
+  # Role constants
+  ZONE_COORDINATOR = 1;
+  SECTION_COORDINATOR = 2;
+  SQUARE_COORDINATOR = 3;
+  PROMOTER = 4;
+  SYMPATHIZER = 5;
 
   attr_accessor :imported
 
@@ -6,8 +12,16 @@ class Voter < ActiveRecord::Base
   validates :latitude, :longitude, :phone_number, :social_network, :role, :email,
     presence: true, if: :user_created_from_app?
 
+  before_create :add_default_role
+
+  private
+
   def user_created_from_app?
     return true if not imported
+  end
+
+  def add_default_role
+    self.role = SYMPATHIZER if self.role.nil?
   end
 
 end

--- a/app/models/voter.rb
+++ b/app/models/voter.rb
@@ -12,12 +12,23 @@ class Voter < ActiveRecord::Base
   validates :latitude, :longitude, :phone_number, :social_network, :role, :email,
     presence: true, if: :user_created_from_app?
 
+  before_validation :check_electoral_number, on: :create
   before_create :add_default_role
 
   private
 
   def user_created_from_app?
     return true if not imported
+  end
+
+  def check_electoral_number
+    voter = Voter.find_by(electoral_number: self.electoral_number)
+
+    if voter.nil?
+      puts 'Saving but need to check the electoral number'
+      return
+    end
+
   end
 
   def add_default_role

--- a/app/models/voter.rb
+++ b/app/models/voter.rb
@@ -1,3 +1,13 @@
 class Voter < ActiveRecord::Base
+
+  attr_accessor :imported
+
   validates_presence_of :full_name, :address, :electoral_number, :section
+  validates :latitude, :longitude, :phone_number, :social_network, :role, :email,
+    presence: true, if: :user_created_from_app?
+
+  def user_created_from_app?
+    return true if not imported
+  end
+
 end

--- a/db/migrate/20170126004403_add_pending_fields_to_voters.rb
+++ b/db/migrate/20170126004403_add_pending_fields_to_voters.rb
@@ -1,0 +1,10 @@
+class AddPendingFieldsToVoters < ActiveRecord::Migration
+  def change
+    add_column :voters, :latitude, :string
+    add_column :voters, :longitude, :string
+    add_column :voters, :phone_number, :string
+    add_column :voters, :social_network, :string
+    add_column :voters, :role, :string
+    add_column :voters, :email, :string
+  end
+end

--- a/db/migrate/20170129190153_add_index_to_voter.rb
+++ b/db/migrate/20170129190153_add_index_to_voter.rb
@@ -1,0 +1,5 @@
+class AddIndexToVoter < ActiveRecord::Migration
+  def change
+    add_index :voters, :electoral_number, unique: true
+  end
+end

--- a/db/migrate/20170129190153_add_index_to_voter.rb
+++ b/db/migrate/20170129190153_add_index_to_voter.rb
@@ -1,5 +1,0 @@
-class AddIndexToVoter < ActiveRecord::Migration
-  def change
-    add_index :voters, :electoral_number, unique: true
-  end
-end

--- a/db/migrate/20170129190153_new_changes_to_voter.rb
+++ b/db/migrate/20170129190153_new_changes_to_voter.rb
@@ -1,0 +1,7 @@
+class NewChangesToVoter < ActiveRecord::Migration
+  def change
+    add_index :voters, :electoral_number, unique: true
+    remove_column :voters, :email
+    add_column :voters, :active, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118033846) do
+ActiveRecord::Schema.define(version: 20170126004403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,12 @@ ActiveRecord::Schema.define(version: 20170118033846) do
     t.string   "section"
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
+    t.string   "latitude"
+    t.string   "longitude"
+    t.string   "phone_number"
+    t.string   "social_network"
+    t.string   "role"
+    t.string   "email"
   end
 
   create_table "zones", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170126004403) do
+ActiveRecord::Schema.define(version: 20170129190153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,9 +38,10 @@ ActiveRecord::Schema.define(version: 20170126004403) do
 
   create_table "messages", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string   "msg_type"
-    t.hstore   "content"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "content_video"
+    t.text     "content_text"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
   create_table "sections", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
@@ -79,6 +80,8 @@ ActiveRecord::Schema.define(version: 20170126004403) do
     t.string   "role"
     t.string   "email"
   end
+
+  add_index "voters", ["electoral_number"], name: "index_voters_on_electoral_number", unique: true, using: :btree
 
   create_table "zones", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string   "name",       limit: 100

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 20170129190153) do
     t.string   "phone_number"
     t.string   "social_network"
     t.string   "role"
-    t.string   "email"
+    t.boolean  "active"
   end
 
   add_index "voters", ["electoral_number"], name: "index_voters_on_electoral_number", unique: true, using: :btree


### PR DESCRIPTION
- Verifies the uniqueness of the Electoral Number whether you are importing the voter or adding it directly from the mobile app. In both ways, it's needed to send the imported (true or false) param to check what fields are required when you are adding a new voter.
- If the voter is created from the app and does not exist in the table, save him/her but need to send a message that we need to verify the Electoral Number (right now I'm justing printing the message with puts)
- Added default validation if the voter does not have a role